### PR TITLE
fix template name

### DIFF
--- a/django_hstore_widget/widgets.py
+++ b/django_hstore_widget/widgets.py
@@ -24,7 +24,7 @@ class HStoreFormWidget(AdminTextareaWidget):
         }
 
         # get template object
-        template = get_template("django_admin_hstore_widget.html")
+        template = get_template("django_hstore_widget.html")
         # render additional html
         additional_html = template.render(template_context)
 


### PR DESCRIPTION
The existing html template is named `django_hstore_widget.html`

This fixes `django.template.exceptions.TemplateDoesNotExist: django_admin_hstore_widget.html`
